### PR TITLE
fix: Path error while setting up shifu demos in local system

### DIFF
--- a/docs/tutorials/demo-try.md
+++ b/docs/tutorials/demo-try.md
@@ -19,6 +19,14 @@ When installing ***Shifu*** installer, five virtual devices are created and conn
 
 ## Preparation
 
+To try out the devices mentioned below make sure to install shifu in your local system from [Quick Install](https://shifu.dev/docs/tutorials/demo-install) before proceeding forward.
+
+After the completion of Quick Install guide  change the directory to `shifudemos` using:
+
+```bash
+cd shifudemos
+```
+
 Start `nginx` to interact with ***deviceShifu***:
 
 ```bash

--- a/docs/tutorials/demo-try.md
+++ b/docs/tutorials/demo-try.md
@@ -19,7 +19,7 @@ When installing ***Shifu*** installer, five virtual devices are created and conn
 
 ## Preparation
 
-To try out the devices mentioned below make sure to install shifu in your local system from [Quick Install](https://shifu.dev/docs/tutorials/demo-install) before proceeding forward.
+To try out the devices mentioned below make sure to install Shifu in your local system from [Quick Install](https://shifu.dev/docs/tutorials/demo-install) before proceeding forward.
 
 After the completion of Quick Install guide  change the directory to `shifudemos` using:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind documentation

#### What this PR does / why we need it:

Adding an instruction in order to hit the right directory to make shifu tutorials work without throwing incorrect path errors.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/Edgenesis/shifu/issues/597

