### PR TITLE
Update Shifu documentation and components for v0.76.0 release

### DIFF
--- a/docs/guides/install/install-shifu-prod.md
+++ b/docs/guides/install/install-shifu-prod.md
@@ -10,7 +10,7 @@ To deploy ***Shifu*** in production environment, you need to [Install Kubernetes
 ***Shifu*** provides a one-click installation where you can use the following command to install ***Shifu*** into your cluster.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/Edgenesis/shifu/v0.75.0/pkg/k8s/crd/install/shifu_install.yml
+kubectl apply -f https://raw.githubusercontent.com/Edgenesis/shifu/v0.76.0/pkg/k8s/crd/install/shifu_install.yml
 ```
 
 :::tip About User Metrics in Shifu

--- a/docs/guides/telemetryservice/installtelemetryservice.md
+++ b/docs/guides/telemetryservice/installtelemetryservice.md
@@ -13,5 +13,5 @@ Make sure you have ***Shifu*** installed first. If you have not installed ***Shi
 ***Shifu*** provides a one-click installation where you can use the following command to install ***telemetryService*** into your cluster.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/Edgenesis/shifu/v0.75.0/pkg/telemetryservice/install/telemetryservice_install.yaml
+kubectl apply -f https://raw.githubusercontent.com/Edgenesis/shifu/v0.76.0/pkg/telemetryservice/install/telemetryservice_install.yaml
 ```

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/install/install-shifu-prod.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/install/install-shifu-prod.md
@@ -10,7 +10,7 @@ sidebar_position: 2
 ***Shifu*** 提供了一键安装的方式，您可以使用如下命令将 ***Shifu*** 安装到您的集群中：
 
 ```bash
-kubectl apply -f https://gitee.com/edgenesis/shifu/raw/v0.75.0/pkg/k8s/crd/install/shifu_install.yml
+kubectl apply -f https://gitee.com/edgenesis/shifu/raw/v0.76.0/pkg/k8s/crd/install/shifu_install.yml
 ```
 
 :::tip 关于用户指标

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/telemetryservice/installtelemetryservice.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/telemetryservice/installtelemetryservice.md
@@ -13,5 +13,5 @@
 ***Shifu***提供了一个一键式安装，你可以使用以下命令将 ***telemetryService*** 安装到你的集群。
 
 ```bash
-kubectl apply -f https://gitee.com/edgenesis/shifu/raw/v0.75.0/pkg/telemetryservice/install/telemetryservice_install.yaml
+kubectl apply -f https://gitee.com/edgenesis/shifu/raw/v0.76.0/pkg/telemetryservice/install/telemetryservice_install.yaml
 ```

--- a/src/components/home/News/index.js
+++ b/src/components/home/News/index.js
@@ -26,8 +26,8 @@ let Lists = [
     img: 'releases.svg',
     // img: require('@site/static/img/home/releases.png').default,
     title: translate({ message: 'Releases' }),
-    message: translate({ message: 'v0.75.0' }),
-    messageLink: 'https://github.com/Edgenesis/shifu/releases/tag/v0.75.0',
+    message: translate({ message: 'v0.76.0' }),
+    messageLink: 'https://github.com/Edgenesis/shifu/releases/tag/v0.76.0',
     link: 'https://github.com/Edgenesis/shifu/releases'
   }
 ]


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR updates the Shifu documentation and components to reference the new v0.76.0 release version. It updates:

- Installation URLs in production deployment guides (both English and Chinese)
- Telemetry service installation URLs (both English and Chinese)  
- Release version displayed on the homepage News component

#### Which issue(s) this PR fixes:

Fixes #

#### How is this PR tested:
- [x] Documentation review
- [ ] unit test
- [ ] e2e test
- [ ] other (please specify)

#### Special notes for your reviewer:

This is a routine version bump for the v0.76.0 release. All changes are straightforward URL and version number updates.

#### Does this PR introduce a user-facing change?

```release-note
Update documentation to reference Shifu v0.76.0 release
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```