### PR TITLE
Update Shifu documentation and components for v0.78.0 release

### DIFF
--- a/docs/guides/install/install-shifu-prod.md
+++ b/docs/guides/install/install-shifu-prod.md
@@ -10,7 +10,7 @@ To deploy ***Shifu*** in production environment, you need to [Install Kubernetes
 ***Shifu*** provides a one-click installation where you can use the following command to install ***Shifu*** into your cluster.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/Edgenesis/shifu/v0.77.0/pkg/k8s/crd/install/shifu_install.yml
+kubectl apply -f https://raw.githubusercontent.com/Edgenesis/shifu/v0.78.0/pkg/k8s/crd/install/shifu_install.yml
 ```
 
 :::tip About User Metrics in Shifu

--- a/docs/guides/telemetryservice/installtelemetryservice.md
+++ b/docs/guides/telemetryservice/installtelemetryservice.md
@@ -13,5 +13,5 @@ Make sure you have ***Shifu*** installed first. If you have not installed ***Shi
 ***Shifu*** provides a one-click installation where you can use the following command to install ***telemetryService*** into your cluster.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/Edgenesis/shifu/v0.77.0/pkg/telemetryservice/install/telemetryservice_install.yaml
+kubectl apply -f https://raw.githubusercontent.com/Edgenesis/shifu/v0.78.0/pkg/telemetryservice/install/telemetryservice_install.yaml
 ```

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/install/install-shifu-prod.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/install/install-shifu-prod.md
@@ -10,7 +10,7 @@ sidebar_position: 2
 ***Shifu*** 提供了一键安装的方式，您可以使用如下命令将 ***Shifu*** 安装到您的集群中：
 
 ```bash
-kubectl apply -f https://gitee.com/edgenesis/shifu/raw/v0.77.0/pkg/k8s/crd/install/shifu_install.yml
+kubectl apply -f https://gitee.com/edgenesis/shifu/raw/v0.78.0/pkg/k8s/crd/install/shifu_install.yml
 ```
 
 :::tip 关于用户指标

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/telemetryservice/installtelemetryservice.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/telemetryservice/installtelemetryservice.md
@@ -13,5 +13,5 @@
 ***Shifu***提供了一个一键式安装，你可以使用以下命令将 ***telemetryService*** 安装到你的集群。
 
 ```bash
-kubectl apply -f https://gitee.com/edgenesis/shifu/raw/v0.77.0/pkg/telemetryservice/install/telemetryservice_install.yaml
+kubectl apply -f https://gitee.com/edgenesis/shifu/raw/v0.78.0/pkg/telemetryservice/install/telemetryservice_install.yaml
 ```

--- a/src/components/home/News/index.js
+++ b/src/components/home/News/index.js
@@ -26,8 +26,8 @@ let Lists = [
     img: 'releases.svg',
     // img: require('@site/static/img/home/releases.png').default,
     title: translate({ message: 'Releases' }),
-    message: translate({ message: 'v0.77.0' }),
-    messageLink: 'https://github.com/Edgenesis/shifu/releases/tag/v0.77.0',
+    message: translate({ message: 'v0.78.0' }),
+    messageLink: 'https://github.com/Edgenesis/shifu/releases/tag/v0.78.0',
     link: 'https://github.com/Edgenesis/shifu/releases'
   }
 ]


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Updates Shifu documentation and components from v0.77.0 to v0.78.0 to reflect the latest release. This includes:

- Updating version references in installation commands for both English and Chinese documentation
- Updating the release link in the home page News component  
- Ensuring all documentation points to the correct v0.78.0 release artifacts

#### Which issue(s) this PR fixes:

N/A - Version update for new release

#### How is this PR tested:
- [x] other (version update - no functional changes)

#### Special notes for your reviewer:

This is a routine version bump from v0.77.0 to v0.78.0. The changes are straightforward version reference updates across documentation files.

#### Does this PR introduce a user-facing change?

```release-note
Update documentation to reference Shifu v0.78.0 release
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```

🤖 Generated with [Claude Code](https://claude.ai/code)