### PR TITLE
[codex] replace stale shifu.run website links

### DIFF
--- a/blog-tech/2022-09-30-meetup.md
+++ b/blog-tech/2022-09-30-meetup.md
@@ -42,7 +42,7 @@ $ sudo kubectl run --image=nginx:1.21 nginx
 
 <img src="/blog-220930/shifu-install.png" width="60%" />
 
-You can also check out [a more detailed tutorial on installing Shifu locally](https://shifu.run/docs/guides/install-shifu-dev).
+You can also check out [a more detailed tutorial on installing Shifu locally](https://shifu.dev/docs/guides/install-shifu-dev).
 
 ## Device Integration
 
@@ -465,4 +465,4 @@ $ sudo kubectl port-forward svc/deviceshifu-camera -n deviceshifu 8080:80
 
 The `Shifu Meetup` event was a huge success. As you can see ***Shifu*** enables developers to quickly access devices, unify various protocols to HTTP for easy management and subsequent application development. ***Shifu*** also has many advantages including running with no single point failure and good isolation.
 
-If you are interested in ***Shifu***, please visit [***Shifu*** official website](https://shifu.run) to learn more. You are also welcome to give the project a star at [***Shifu***'s GitHub repository](https://github.com/Edgenesis/shifu)!
+If you are interested in ***Shifu***, please visit [***Shifu*** official website](https://shifu.dev) to learn more. You are also welcome to give the project a star at [***Shifu***'s GitHub repository](https://github.com/Edgenesis/shifu)!

--- a/blog-tech/2022-10-18-shifu-cloud.md
+++ b/blog-tech/2022-10-18-shifu-cloud.md
@@ -22,7 +22,7 @@ $ sudo kubectl apply -f pkg/k8s/crd/install/shifu_install.yml
 
 <img src="/blog-221018/01.png" width="100%" />
 
-If you would like to know how to install ***Shifu*** and test it locally, you may want to check out [download and install](https://shifu.run/zh-Hans/docs/tutorials/demo-install) and [local installing testing](https://shifu.run/zh-Hans/docs/guides/install-shifu-dev).
+If you would like to know how to install ***Shifu*** and test it locally, you may want to check out [download and install](https://shifu.dev/zh-Hans/docs/tutorials/demo-install) and [local installing testing](https://shifu.dev/zh-Hans/docs/guides/install-shifu-dev).
 
 ## Connecting to thermometer and LED
 

--- a/docs/guides/install/demo-update-delete-recover.md
+++ b/docs/guides/install/demo-update-delete-recover.md
@@ -11,7 +11,7 @@ sidebar_position: 3
 Please uninstall the old version of ***Shifu*** before installing the new version of ***Shifu*** Demo.
 :::
 
-Go to [Download **Shifu** Demo](https://shifu.run/disclaimer) to download the latest ***Shifu*** installer.
+Go to [Download **Shifu** Demo](https://shifu.dev/disclaimer) to download the latest ***Shifu*** installer.
 
 :::note
 ***Shifu*** Demo installer will be updated when ***Shifu*** is updated.

--- a/docs/tutorials/demo-install.md
+++ b/docs/tutorials/demo-install.md
@@ -103,7 +103,7 @@ If the output is `Cannot connect to the Docker daemon at unix:///var/run/docker.
 
 ## Install ***Shifu***
 
-Go to [**Shifu Demo Download**](https://shifu.run/disclaimer) to download the ***Shifu*** installation package and follow the instructions on the website to install it.
+Go to [**Shifu Demo Download**](https://shifu.dev/disclaimer) to download the ***Shifu*** installation package and follow the instructions on the website to install it.
 
 Go directly to the second step in the page and return to this page when you are done.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,7 +15,7 @@ const config = {
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: "edgenesis", // Usually your GitHub org/user name.
-  projectName: "shifu.run", // Usually your repo name.
+  projectName: "shifu.dev", // Usually your repo name.
 
   // https://docusaurus.io/docs/i18n/tutorial#start-your-site
   // https://docusaurus.io/docs/api/docusaurus-config#i18n
@@ -89,7 +89,7 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           sidebarCollapsible: true, // make sidebar expandable
           routeBasePath: "/docs",
-          editUrl: "https://github.com/edgenesis/shifu.run/tree/main/",
+          editUrl: "https://github.com/Edgenesis/shifu.dev/tree/main/",
         },
         blog: false,
         theme: {

--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -188,8 +188,8 @@
   "Interact with the AGV": {
     "message": "与AGV的数字孪生交互"
   },
-  "https://shifu.run/docs/tutorials/demo-try#1-interact-with-the-agv": {
-    "message": "https://shifu.run/zh-Hans/docs/tutorials/demo-try#1-与agv交互"
+  "https://shifu.dev/docs/tutorials/demo-try#1-interact-with-the-agv": {
+    "message": "https://shifu.dev/zh-Hans/docs/tutorials/demo-try#1-与agv交互"
   },
   "Case Two": {
     "message": "案例二"
@@ -197,8 +197,8 @@
   "Interact with the thermometer": {
     "message": "与温度计的数字孪生交互"
   },
-  "https://shifu.run/docs/tutorials/demo-try#2-interact-with-the-thermometer": {
-    "message": "https://shifu.run/zh-Hans/docs/tutorials/demo-try#2-与温度计交互"
+  "https://shifu.dev/docs/tutorials/demo-try#2-interact-with-the-thermometer": {
+    "message": "https://shifu.dev/zh-Hans/docs/tutorials/demo-try#2-与温度计交互"
   },
   "Case Three": {
     "message": "案例三"
@@ -206,8 +206,8 @@
   "Interact with the microplate reader": {
     "message": "与酶标仪的数字孪生交互"
   },
-  "https://shifu.run/docs/tutorials/demo-try#3-interact-with-the-microplate-reader": {
-    "message": "https://shifu.run/zh-Hans/docs/tutorials/demo-try#3-与酶标仪交互"
+  "https://shifu.dev/docs/tutorials/demo-try#3-interact-with-the-microplate-reader": {
+    "message": "https://shifu.dev/zh-Hans/docs/tutorials/demo-try#3-与酶标仪交互"
   },
   "Case Four": {
     "message": "案例四"
@@ -215,8 +215,8 @@
   "Interact with the PLC": {
     "message": "与PLC的数字孪生交互"
   },
-  "https://shifu.run/docs/tutorials/demo-try#4-interact-with-the-plc": {
-    "message": "https://shifu.run/zh-Hans/docs/tutorials/demo-try#4-与plc交互"
+  "https://shifu.dev/docs/tutorials/demo-try#4-interact-with-the-plc": {
+    "message": "https://shifu.dev/zh-Hans/docs/tutorials/demo-try#4-与plc交互"
   },
   "Case Five": {
     "message": "案例五"
@@ -224,8 +224,8 @@
   "Interact with the robotic arm": {
     "message": "与机械臂的数字孪生交互"
   },
-  "https://shifu.run/docs/tutorials/demo-try#5-interact-with-the-robotic-arm": {
-    "message": "https://shifu.run/zh-Hans/docs/tutorials/demo-try#5-与机械臂交互"
+  "https://shifu.dev/docs/tutorials/demo-try#5-interact-with-the-robotic-arm": {
+    "message": "https://shifu.dev/zh-Hans/docs/tutorials/demo-try#5-与机械臂交互"
   },
   "Confirm nginx starts": {
     "message": "确认是否启动Nginx"
@@ -519,8 +519,8 @@
     "message": "搜索",
     "description": "The ARIA label and placeholder for search button"
   },
-  "https://shifu.run/docs/tutorials/demo-try": {
-    "message": "https://shifu.run/zh-Hans/docs/tutorials/demo-try"
+  "https://shifu.dev/docs/tutorials/demo-try": {
+    "message": "https://shifu.dev/zh-Hans/docs/tutorials/demo-try"
   },
   "theme.tags.tagsPageTitle": {
     "message": "标签",

--- a/i18n/zh-Hans/docusaurus-plugin-content-blog-technical-blogs/2022-09-30-meetup.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-blog-technical-blogs/2022-09-30-meetup.md
@@ -42,7 +42,7 @@ $ sudo kubectl run --image=nginx:1.21 nginx
 
 <img src="/blog-220930/shifu-install.png" width="60%" />
 
-您也可以查看[更详细的本地安装Shifu教程](https://shifu.run/docs/guides/install-shifu-dev)。
+您也可以查看[更详细的本地安装Shifu教程](https://shifu.dev/docs/guides/install-shifu-dev)。
 
 ## 设备接入
 
@@ -468,4 +468,4 @@ $ sudo kubectl port-forward svc/deviceshifu-camera -n deviceshifu 8080:80
 
 此次 `Shifu Meetup` 活动的顺利举办。可以看到 ***Shifu*** 能够让开发者快速接入设备、将各种协议统一转为HTTP方便管理和后续应用开发。***Shifu*** 也有无单点故障、隔离性好等多种优势。
 
-如果您对 ***Shifu*** 产生兴趣，欢迎访问 [***Shifu***官网](https://shifu.run/zh-Hans/) 了解更多。也欢迎您在 [***Shifu***的GitHub仓库](https://github.com/Edgenesis/shifu) 给项目一个star！
+如果您对 ***Shifu*** 产生兴趣，欢迎访问 [***Shifu***官网](https://shifu.dev/zh-Hans/) 了解更多。也欢迎您在 [***Shifu***的GitHub仓库](https://github.com/Edgenesis/shifu) 给项目一个star！

--- a/i18n/zh-Hans/docusaurus-plugin-content-blog-technical-blogs/2022-10-18-shifu-cloud.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-blog-technical-blogs/2022-10-18-shifu-cloud.md
@@ -22,7 +22,7 @@ $ sudo kubectl apply -f pkg/k8s/crd/install/shifu_install.yml
 
 <img src="/blog-221018/01.png" width="100%" />
 
-如果你还不了解 ***Shifu*** 的安装和本地测试的方式，你可能需要查阅 [下载安装](https://shifu.run/zh-Hans/docs/tutorials/demo-install) 和 [本机安装测试](https://shifu.run/zh-Hans/docs/guides/install-shifu-dev) 这两篇文档。
+如果你还不了解 ***Shifu*** 的安装和本地测试的方式，你可能需要查阅 [下载安装](https://shifu.dev/zh-Hans/docs/tutorials/demo-install) 和 [本机安装测试](https://shifu.dev/zh-Hans/docs/guides/install-shifu-dev) 这两篇文档。
 
 ## 本机连接温湿度计和LED
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/community/contribute-shifu.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/community/contribute-shifu.md
@@ -10,6 +10,6 @@ sidebar_position: 0
 
 对于shifu支持目前暂不支持的协议，可以参考[接入尚未支持的协议](https://github.com/Edgenesis/shifu/blob/main/docs/development/develop-deviceshifu.md)，在[***Shifu*** 仓库](https://github.com/Edgenesis/shifu)中贡献新的 ***deviceshifu*** 类型。
 ## 贡献文档
-欢迎前往 [shifu.dev 仓库](https://github.com/Edgenesis/shifu.run)，[提交 Issue](https://github.com/Edgenesis/shifu.run/issues/new/choose) 或 [提交 Pull Request](https://github.com/Edgenesis/shifu.run/compare)！
+欢迎前往 [shifu.dev 仓库](https://github.com/Edgenesis/shifu.dev)，[提交 Issue](https://github.com/Edgenesis/shifu.dev/issues/new/choose) 或 [提交 Pull Request](https://github.com/Edgenesis/shifu.dev/compare)！
 
 您也可以直接点击文章下方的 `编辑此页` 跳转到 GitHub 进行在线编辑。

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/install/demo-update-delete-recover.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/install/demo-update-delete-recover.md
@@ -11,7 +11,7 @@ sidebar_position: 3
 在安装新版 ***Shifu*** Demo 之前请先卸载老版本的 ***Shifu***。
 :::
 
-前往 [**Shifu** Demo 下载](https://shifu.run/zh-Hans/disclaimer) 页面 下载最新的 ***Shifu*** 安装包。
+前往 [**Shifu** Demo 下载](https://shifu.dev/zh-Hans/disclaimer) 页面 下载最新的 ***Shifu*** 安装包。
 
 :::note
 ***Shifu*** Demo 安装包会随着 ***Shifu***自动更新。

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/demo-install.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/demo-install.md
@@ -106,7 +106,7 @@ sudo docker ps
 
 ## 安装 ***Shifu***
 
-前往 [**Shifu Demo 下载**](https://shifu.run/disclaimer) 下载 ***Shifu*** 安装包并按照网站的指导安装。
+前往 [**Shifu Demo 下载**](https://shifu.dev/disclaimer) 下载 ***Shifu*** 安装包并按照网站的指导安装。
 
 直接进入页面中的第二步，完成后即可回到本页面
 

--- a/src/components/demo/demoContent/components/stepThree/index.js
+++ b/src/components/demo/demoContent/components/stepThree/index.js
@@ -3,7 +3,6 @@ import React from 'react';
 import styles from "./styles.module.scss";
 import { ButtonSquare } from "../../../button";
 import CodeView from '../../../codeVIew';
-const ShifuCloudLogo = require('@site/static/img/logo/shifucloud-logo.svg').default
 
 /*
  * codeViewStyle and codeViewDescriptionStyle for modify the codeView component style
@@ -68,51 +67,37 @@ const btnList = [
     colorLevel: 'three',
     content: <div><p><Translate>Case One</Translate></p><p><Translate>Interact with the AGV</Translate></p></div>,
     contentStyle: buttonContentStyle,
-    url: translate({ message: "https://shifu.run/docs/tutorials/demo-try#1-interact-with-the-agv" })
+    url: translate({ message: "https://shifu.dev/docs/tutorials/demo-try#1-interact-with-the-agv" })
   },
   {
     id: 2,
     colorLevel: 'three',
     content: <div><p><Translate>Case Two</Translate></p><p><Translate>Interact with the thermometer</Translate></p></div>,
     contentStyle: buttonContentStyle,
-    url: translate({ message: "https://shifu.run/docs/tutorials/demo-try#2-interact-with-the-thermometer" })
+    url: translate({ message: "https://shifu.dev/docs/tutorials/demo-try#2-interact-with-the-thermometer" })
   },
   {
     id: 3,
     colorLevel: 'three',
     content: <div><p><Translate>Case Three</Translate></p><p><Translate>Interact with the microplate reader</Translate></p></div>,
     contentStyle: buttonContentStyle,
-    url: translate({ message: "https://shifu.run/docs/tutorials/demo-try#3-interact-with-the-microplate-reader" })
+    url: translate({ message: "https://shifu.dev/docs/tutorials/demo-try#3-interact-with-the-microplate-reader" })
   },
   {
     id: 4,
     colorLevel: 'three',
     content: <div><p><Translate>Case Four</Translate></p><p><Translate>Interact with the PLC</Translate></p></div>,
     contentStyle: buttonContentStyle,
-    url: translate({ message: "https://shifu.run/docs/tutorials/demo-try#4-interact-with-the-plc" })
+    url: translate({ message: "https://shifu.dev/docs/tutorials/demo-try#4-interact-with-the-plc" })
   },
   {
     id: 5,
     colorLevel: 'three',
     content: <div><p><Translate>Case Five</Translate></p><p><Translate>Interact with the robotic arm</Translate></p></div>,
     contentStyle: buttonContentStyle,
-    url: translate({ message: "https://shifu.run/docs/tutorials/demo-try#5-interact-with-the-robotic-arm" })
+    url: translate({ message: "https://shifu.dev/docs/tutorials/demo-try#5-interact-with-the-robotic-arm" })
   },
 ]
-
-function ActiveLine() {
-  let spotList = [0, 1, 2, 3, 4, 5, 6, 7]
-  const spots = spotList.map((item) => {
-    let delay = 0.3 * item;
-    let left = 20 * item;
-    return <div className={styles.spot} style={{ animationDelay: `${delay}s`, left: `${left}px` }}></div>
-  })
-  return (
-    <div className={styles.activeLine}>
-      {spots}
-    </div>
-  )
-}
 
 class StepThree extends React.Component {
   constructor(props) {
@@ -163,13 +148,6 @@ class StepThree extends React.Component {
             <ButtonSquare colorLevel="one" content={translate({ message: "Start trying out" })} target="_blank" href={this.state.btnInfo.url}></ButtonSquare>
           </div>
         </div>
-        {/* <div className={styles.enterShifuCloud}>
-          <ActiveLine></ActiveLine>
-          <a href='https://cloud.shifu.run/' target='_blank' className={styles.shifuCloud}>
-            <ShifuCloudLogo></ShifuCloudLogo>
-          </a>
-          <p className={styles.shifuCloudContent}><Translate>免费试用Shifu Cloud</Translate></p>
-        </div> */}
       </div>
     )
   }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

Replaces stale public `shifu.run` links with current `shifu.dev` links across docs, blog content, demo navigation, Chinese translations, and Docusaurus edit links. It also removes a dead commented `cloud.shifu.run` demo block from source.

`shifu.run` no longer resolves, while the corresponding `shifu.dev` pages and demo disclaimer page are live. This keeps users on working documentation and demo paths.

#### Which issue(s) this PR fixes:

N/A

#### How is this PR tested:
- [ ] unit test
- [ ] e2e test
- [x] other (please specify): `bun run build`

#### Special notes for your reviewer:

This PR intentionally leaves `azure-pipelines/deploy.yml` deployment-internal names alone. The endpoint and `/var/www/shifu.run` path may be legacy deployment plumbing for the current site host, so changing them should be handled separately with server-side deploy verification.

#### Does this PR introduce a user-facing change?

Yes, stale website links now point at `shifu.dev` instead of the non-resolving `shifu.run` domain.

```release-note
Fixed stale shifu.run links in website docs and demo pages to point at shifu.dev.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```